### PR TITLE
Fix linked browse (ASC-44)

### DIFF
--- a/frontend/views/accessions/index.html.erb
+++ b/frontend/views/accessions/index.html.erb
@@ -4,9 +4,12 @@
   # Start of modifications
   # Customize accession browse columns
   # See https://github.com/archivesspace/archivesspace/blob/master/frontend/app/helpers/search_helper.rb
+
+  # Add standard columns minus actions
   model = "accession"
   add_multiselect_column if can_delete_search_results?(model) && !(request.path =~ /\/(advanced_)*search/)
   add_pref_columns(model)
+
   # Add content_description column
   prop = 'content_description'
   enum_locale_key = "#{model}_#{prop}"
@@ -18,7 +21,10 @@
       I18n.t("enumerations.#{enum_locale_key}.#{v}", :default => v.to_s) unless v.nil?
     }
   )
+
+  # Add the actions column
   add_actions_column
+
   # End of modifications
 %>
 

--- a/frontend/views/accessions/index.html.erb
+++ b/frontend/views/accessions/index.html.erb
@@ -2,10 +2,11 @@
 
 <%
   # Start of modifications
+  # Customize accession browse columns
   # See https://github.com/archivesspace/archivesspace/blob/master/frontend/app/helpers/search_helper.rb
   model = "accession"
   add_pref_columns(model)
-  # Add content_description column at end
+  # Add content_description column
   prop = 'content_description'
   enum_locale_key = "#{model}_#{prop}"
   add_column(
@@ -16,7 +17,7 @@
       I18n.t("enumerations.#{enum_locale_key}.#{v}", :default => v.to_s) unless v.nil?
     }
   )
-  add_actions_column if !params[:linker] || params[:linker] === 'false'
+  add_actions_column
   # End of modifications
 %>
 

--- a/frontend/views/accessions/index.html.erb
+++ b/frontend/views/accessions/index.html.erb
@@ -5,6 +5,7 @@
   # Customize accession browse columns
   # See https://github.com/archivesspace/archivesspace/blob/master/frontend/app/helpers/search_helper.rb
   model = "accession"
+  add_multiselect_column if can_delete_search_results?(model) && !(request.path =~ /\/(advanced_)*search/)
   add_pref_columns(model)
   # Add content_description column
   prop = 'content_description'

--- a/frontend/views/accessions/index.html.erb
+++ b/frontend/views/accessions/index.html.erb
@@ -7,7 +7,7 @@
 
   # Add standard columns minus actions
   model = "accession"
-  add_multiselect_column if can_delete_search_results?(model) && !(request.path =~ /\/(advanced_)*search/)
+  add_multiselect_column if can_delete_search_results?(model)
   add_pref_columns(model)
 
   # Add content_description column

--- a/frontend/views/search/_results.html.erb
+++ b/frontend/views/search/_results.html.erb
@@ -4,14 +4,20 @@
 
 <%
   # Start of modifications
-  # Customize accession columns only in search results, when creating linked entities
+  # See https://github.com/archivesspace/archivesspace/blob/master/frontend/app/helpers/search_helper.rb
+  # Customize columns in search results if accessions might be included
+
   model = "accession"
-  if !@search_data.nil? && @search_data.get_type == model
-    # See https://github.com/archivesspace/archivesspace/blob/master/frontend/app/helpers/search_helper.rb
-    add_linker_column if params[:linker] === 'true'
-    add_pref_columns(model)
+  if !@search_data.nil? & [model, "multi"].include?(@search_data.get_type)
+    # Add standard columns for results
+    add_columns
+
+    # Remove actions column if it was added by add_columns
+    is_not_linker = !params[:linker] || params[:linker] === 'false'
+    @columns.pop if is_not_linker
+
     # Add content_description column
-    prop = 'content_description'
+    prop = "content_description"
     enum_locale_key = "#{model}_#{prop}"
     add_column(
       I18n.t("#{model}.#{prop}"),
@@ -21,8 +27,11 @@
         I18n.t("enumerations.#{enum_locale_key}.#{v}", :default => v.to_s) unless v.nil?
       }
     )
-    add_actions_column if !params[:linker] || params[:linker] === 'false'
+
+    # Add back actions column if necessary
+    add_actions_column if is_not_linker
   end
+
   # End of modifications
 %>
 

--- a/frontend/views/search/_results.html.erb
+++ b/frontend/views/search/_results.html.erb
@@ -4,21 +4,25 @@
 
 <%
   # Start of modifications
-  # See https://github.com/archivesspace/archivesspace/blob/master/frontend/app/helpers/search_helper.rb
+  # Customize accession columns only in search results, when creating linked entities
   model = "accession"
-  add_pref_columns(model)
-  # Add content_description column at end
-  prop = 'content_description'
-  enum_locale_key = "#{model}_#{prop}"
-  add_column(
-    I18n.t("#{model}.#{prop}"),
-    { locale_key: enum_locale_key, model: model, sortable: false },
-    proc { |record|
-      v = record[prop] || ASUtils.json_parse(record['json'])[prop]
-      I18n.t("enumerations.#{enum_locale_key}.#{v}", :default => v.to_s) unless v.nil?
-    }
-  )
-  add_actions_column if !params[:linker] || params[:linker] === 'false'
+  if !@search_data.nil? && @search_data.get_type == model
+    # See https://github.com/archivesspace/archivesspace/blob/master/frontend/app/helpers/search_helper.rb
+    add_linker_column if params[:linker] === 'true'
+    add_pref_columns(model)
+    # Add content_description column
+    prop = 'content_description'
+    enum_locale_key = "#{model}_#{prop}"
+    add_column(
+      I18n.t("#{model}.#{prop}"),
+      { locale_key: enum_locale_key, model: model, sortable: false },
+      proc { |record|
+        v = record[prop] || ASUtils.json_parse(record['json'])[prop]
+        I18n.t("enumerations.#{enum_locale_key}.#{v}", :default => v.to_s) unless v.nil?
+      }
+    )
+    add_actions_column if !params[:linker] || params[:linker] === 'false'
+  end
   # End of modifications
 %>
 


### PR DESCRIPTION
This PR aims to resolve [ASC-44](https://mlit.atlassian.net/jira/software/projects/ASC/boards/88?selectedIssue=ASC-44). It fixes a couple of bugs I found that were introduced by #1.

Test plan

Setup

In `aspace-containerization`, modify line 11 of `app/instances/clements/Dockerfile.clements` to be the following:
```
git clone --depth 1 --branch asc-44-fix-linked-browse https://github.com/mlibrary/aspace-clements-customization.git
```

Then build the images.
```
docker compose --progress=plain build --build-arg ASPACE_VERSION=v3.4.1
docker compose --f instances.yaml build clements
```

To follow the next commands, you'll need a MySQL dump file, or you could skip the restoration and create a few of your own entities in the bare database (two accessions, a subject, and a resource referencing "test" should suffice).

```
docker compose -f instances.yaml up db 
docker cp path/to/dumpfile.sql aspace-containerization-db-1:/tmp/dumpfile.sql
docker exec -it aspace-containerization-db-1 /bin/bash
mysql -u as --password archivesspace < tmp/dumpfile.sql
docker compose -f instances.yaml down
```

```
docker compose -f instances.yaml up db solr clements
```

## Tests

When browsing accessions (Browse > Accessions),

1) users can see the  "Content Description" column.
1) user has the ability to use the View and Edit actions (last column) as appropriate for their permissions.
1) if the user has delete permissions, user can select some or all of the accessions and click the Delete button to open a dialog (don't need to test actual deletion).

When searching for "test" in the field on the homepage,

1) in the results there is a "Resource Type" column with multiple types, and "Content Description" is present.
1) in the results, if you facet on only Resources, only the resource-specific columns are shown.
1) in the results, if you facet on only Accessions, "Content Description" column is still present.

When creating a new accession (Create > Accession),

1) when linking a Subject, the Browse option displays the appropriate Subject-specific columns ("Terms") and the rows are selectable.
1) when linking a Related Accession, the Browse option displays the appropriate accession-specific columns (including "Content Description") and the rows are selectable.